### PR TITLE
Add the possibility to insert the amount with a comma instead of a dot

### DIFF
--- a/records.py
+++ b/records.py
@@ -3,6 +3,7 @@ import sheet
 
 
 def parse_outcome_amount(amount: str) -> float | None:
+    amount = amount.replace(",", ".")
     if amount[0] == "+" or amount[0] == "-":
         amount = amount[1:]
     amount = "-" + amount
@@ -14,6 +15,7 @@ def parse_outcome_amount(amount: str) -> float | None:
 
 
 def parse_income_amount(amount: str) -> float | None:
+    amount = amount.replace(",", ".")
     if amount[0] == "-":
         amount = amount[1:]
     try:


### PR DESCRIPTION
In many European countries (and maybe elsewhere), floating point numbers are written with the comma instead of the dot (e.g., 3,14 instead of 3.14), but Python doesn't permit casting a string written in this way to a float. So I added a simple `replace("," ".")` to the functions that take the amount and cast it to float, to deal with an input of this kind.

This is useful only for those people who are used to writing numbers in this way and it doesn't change anything for the rest of the world.
